### PR TITLE
Adds a deno type resolver

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -226,7 +226,7 @@ const LibManager = {
           // Get the path of the root d.ts file
   
           // non-inferred route
-          let rootTypePath = responseJSON.typing
+          let rootTypePath = responseJSON.typing || responseJSON.types
           
           // package main is custom 
           if (!rootTypePath && typeof responseJSON.main === 'string' && responseJSON.main.indexOf('.js') > 0) {


### PR DESCRIPTION
Also not comprehensive, but maybe good enough for quick demos. To do this completely there'd need to be a virtual project also and some way for TS to handle the extremely ephemeral FS. So, this is enough for now.

The underlaying idea is that deno uses raw http urls for the imports and it will cache them, so the resolver now supports grabbing those urls but struggles with handling the relative imports between them

![Screen Shot 2019-08-06 at 10 25 57 PM](https://user-images.githubusercontent.com/49038/62590122-5cec2e00-b899-11e9-9570-c6c3950f3892.png)

