### PR TITLE
fix the expression that detects the JSX option

### DIFF
--- a/public/main-0.js
+++ b/public/main-0.js
@@ -447,7 +447,7 @@ async function main() {
   }
 
   function createFile(compilerOptions) {
-    const isJSX = compilerOptions.jsx === monaco.languages.typescript.JsxEmit.None
+    const isJSX = compilerOptions.jsx !== monaco.languages.typescript.JsxEmit.None
     const fileExt = window.CONFIG.useJavaScript ? "js" : "ts"
     const ext = isJSX ? fileExt + "x" : fileExt
     const filepath = "input." + ext


### PR DESCRIPTION
Currently, the JSX option detection is reversed and does not seem to work.
Below is the original code part.
https://github.com/agentcooper/typescript-play/blob/master/public/main.js#L185-L189

There is a mismatch between the `filepath` in the `createFile` function and the selected compiler option.
Therefore, even if JSX is changed to React, the JSX sample code remains in error.
And, if you write an example of type assertion using `<>`, JSX does not work in None but works in React.
