### PR TITLE
Adds nightly builds to the playground

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -203,8 +203,12 @@ img {
           {},
           {
             // https://unpkg.com/monaco-editor/
+            // The TS version is bundled inside monaco-editor, so this config file maps
+            // the version of TS to a specific build of monaco-editor which runs with
+            // that TS version embedded
             "3.6.3": { monaco: "0.18.0", module: "@orta/monaco-editor" },
-            // "Nightly": { monaco: "3.7.0-dev.20190917", module: "@typescript-deploys/monaco-editor" },
+            // See: https://github.com/orta/make-monaco-builds
+            "Nightly": { monaco: "nightly", module: "@typescript-deploys/monaco-editor" },
             "3.5.1": { monaco: "0.17.1", module: "monaco-editor"},
             "3.3.3": { monaco: "0.16.1", module: "monaco-editor"},
             "3.1.6": { monaco: "0.15.6", module: "monaco-editor"},
@@ -222,6 +226,7 @@ img {
         siteRoot: location.protocol + "//" + location.host,
         getLatestVersion() {
           return Object.keys(this.availableTSVersions)
+            .filter(key => key !== "Nightly")
             .sort()
             .pop();
         },

--- a/public/main-0.js
+++ b/public/main-0.js
@@ -756,7 +756,11 @@ async function main() {
       }
       // set the first selection by default
       const sections = document.getElementsByClassName("section-name")
-      sections[0].onclick()
+      if (!sections[0]) {
+        console.warning("In dev mode you need to save a file in the examples to get the changes into the dev folder")
+      } else {
+        sections[0].onclick()
+      }
     },
 
     selectExample: async function(exampleName) {
@@ -918,7 +922,7 @@ console.log(message);
 
   window.MonacoEnvironment = {
     getWorkerUrl: function(workerId, label) {
-      return `worker.js?version=${window.CONFIG.getMonacoVersion()}`;
+      return `worker.js?version=${window.CONFIG.getMonacoVersion()}&editorModule=${window.CONFIG.getMonacoModule()}`;
     },
   };
 

--- a/public/worker.js
+++ b/public/worker.js
@@ -1,9 +1,14 @@
 const params = new URLSearchParams(location.search);
 const version = params.get("version");
+const editorModule = params.get("editorModule");
 
 if (!version) {
   throw new Error(`Pass ?version= to worker.js.`);
 }
 
-self.MonacoEnvironment = { baseUrl: `https://unpkg.com/monaco-editor@${version}/min` };
-importScripts(`https://unpkg.com/monaco-editor@${version}/min/vs/base/worker/workerMain.js`);
+if (!editorModule) {
+  throw new Error(`Pass ?editorModule= to worker.js.`);
+}
+
+self.MonacoEnvironment = { baseUrl: `https://unpkg.com/${editorModule}@${version}/min` };
+importScripts(`https://unpkg.com/${editorModule}@${version}/min/vs/base/worker/workerMain.js`);


### PR DESCRIPTION
Passes the module name around to workers and uses the newly shipped nightly deploys