### PR TITLE
Sets the URL to be an exact version when doing nightlies

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -243,11 +243,7 @@ img {
         },
 
         useTSVersion(version) {
-          if (this.availableTSVersions[version]) {
-            this.TSVersion = version;
-          } else {
-            this.TSVersion = "PR"
-          }
+          this.TSVersion = version
         },
 
         getMonacoModule() {

--- a/public/main-2.js
+++ b/public/main-2.js
@@ -911,7 +911,13 @@ async function main() {
 
       ["lib", "ts"].forEach(param => {
         if (params.has(param)) {
-          urlParams[param] = params.get(param);
+          // Special case the nightly where it uses the TS version to hardcode
+          // the nightly build
+          if (param === "ts" && params.get(param) === "Nightly") {
+            urlParams[param] = window.ts.version
+          } else {
+            urlParams[param] = params.get(param);
+          }
         }
       });
 


### PR DESCRIPTION
Hitting nightly will pull out the version number from the `window.ts` and use that for the URL when it updates so that the sharing link shows the exact version.

![Screen Shot 2019-10-22 at 12 04 55 PM](https://user-images.githubusercontent.com/49038/67306067-5e0a2000-f4c4-11e9-961e-54fc8d138087.png)
