### PR TITLE
[WIP] Export to ... support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -360,6 +360,17 @@ img {
             </ul>
 
             <ul class="nav navbar-nav navbar-right hidden-xs">
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Export <span class="caret"></span></a>
+                    <ul class="dropdown-menu">
+                      <li><a id="export-create-gh-issue" href="#">Report GitHub issue on TypeScript</a></li>
+                      <li><a id="export-copy-markdown" href="#">Copy as Markdown</a></li>
+                      <li role="separator" class="divider"></li>
+                      <li><a id="export-open-code-sandbox" href="#">Open in CodeSandbox</a></li>
+                      <li><a id="export-open-stackblitz"href="#" onclick="exporter.openProjectInStackBlitz()">Open in StackBlitz</a></li>
+                    </ul>
+                  </li>
+
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Shortcuts <span class="caret"></span></a>
                 <ul class="dropdown-menu">
@@ -431,6 +442,7 @@ img {
       $('#config').on('click', function(e) {
         e.stopPropagation();
       });
+
     </script>
 
 


### PR DESCRIPTION
Currently works with StackBlitz

- I have some notes in https://github.com/microsoft/TypeScript-Website/issues/46 about the code sandbox API
- I'd expect the link to make an issue to work like the [prettier playground](https://prettier.io/playground/) see bottom right
- Not sure wha to expect from copy to markdown, maybe a popover with a textarea previewing it and selected for you to copy

**note to work on this**, you need to get a copy of the website https://github.com/microsoft/TypeScript-website#configure-your-build-environment then change the submodule in `src/play` to be these commits.

![Screen Shot 2019-10-25 at 12 12 57 PM](https://user-images.githubusercontent.com/49038/67586941-cead7880-f720-11e9-8e22-134f3f665120.png)

![Screen Shot 2019-10-25 at 12 13 13 PM](https://user-images.githubusercontent.com/49038/67587126-319f0f80-f721-11e9-8769-fee8f2bf6dc0.png)
