### PR TITLE
Feature: Add export buttons options

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -360,6 +360,17 @@ img {
             </ul>
 
             <ul class="nav navbar-nav navbar-right hidden-xs">
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Export <span class="caret"></span></a>
+                    <ul class="dropdown-menu">
+                      <li><a id="export-create-gh-issue" href="#">Report GitHub issue on TypeScript</a></li>
+                      <li><a id="export-copy-markdown" href="#">Copy as Markdown</a></li>
+                      <li role="separator" class="divider"></li>
+                      <li><a id="export-open-code-sandbox" href="#">Open in CodeSandbox</a></li>
+                      <li><a id="export-open-stackblitz"href="#" onclick="exporter.openProjectInStackBlitz()">Open in StackBlitz</a></li>
+                    </ul>
+                  </li>
+
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Shortcuts <span class="caret"></span></a>
                 <ul class="dropdown-menu">
@@ -431,6 +442,7 @@ img {
       $('#config').on('click', function(e) {
         e.stopPropagation();
       });
+
     </script>
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -366,7 +366,7 @@ img {
                       <li><a id="export-create-gh-issue" href="#">Report GitHub issue on TypeScript</a></li>
                       <li><a id="export-copy-markdown" href="#">Copy as Markdown</a></li>
                       <li role="separator" class="divider"></li>
-                      <li><a id="export-open-code-sandbox" href="#">Open in CodeSandbox</a></li>
+                      <li><a id="export-open-code-sandbox" href="#" onclick="exporter.openProjectInCodeSandbox()">Open in CodeSandbox</a></li>
                       <li><a id="export-open-stackblitz"href="#" onclick="exporter.openProjectInStackBlitz()">Open in StackBlitz</a></li>
                     </ul>
                   </li>

--- a/public/index.html
+++ b/public/index.html
@@ -364,7 +364,10 @@ img {
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Export <span class="caret"></span></a>
                     <ul class="dropdown-menu">
                       <li><a id="export-create-gh-issue" href="#" onclick="exporter.reportIssue()">Report GitHub issue on TypeScript</a></li>
-                      <li><a id="export-copy-markdown" href="#" onclick="exporter.copyAsMarkdown()">Copy as Markdown</a></li>
+                      <li role="separator" class="divider"></li>
+                      <li><a id="export-copy-issue-markdown" href="#" onclick="exporter.copyAsMarkdownIssue()">Copy as Markdown Issue</a></li>
+                      <li><a id="export-copy-markdown" href="#" onclick="exporter.copyForChat()">Copy as Markdown Link</a></li>
+                      <li><a id="export-copy-markdown" href="#" onclick="exporter.copyForChatWithPreview()">Copy as Markdown Link with Preview</a></li>
                       <li role="separator" class="divider"></li>
                       <li><a id="export-open-code-sandbox" href="#" onclick="exporter.openProjectInCodeSandbox()">Open in CodeSandbox</a></li>
                       <li><a id="export-open-stackblitz"href="#" onclick="exporter.openProjectInStackBlitz()">Open in StackBlitz</a></li>

--- a/public/index.html
+++ b/public/index.html
@@ -364,7 +364,7 @@ img {
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Export <span class="caret"></span></a>
                     <ul class="dropdown-menu">
                       <li><a id="export-create-gh-issue" href="#" onclick="exporter.reportIssue()">Report GitHub issue on TypeScript</a></li>
-                      <li><a id="export-copy-markdown" href="#">Copy as Markdown</a></li>
+                      <li><a id="export-copy-markdown" href="#" onclick="exporter.copyAsMarkdown()">Copy as Markdown</a></li>
                       <li role="separator" class="divider"></li>
                       <li><a id="export-open-code-sandbox" href="#" onclick="exporter.openProjectInCodeSandbox()">Open in CodeSandbox</a></li>
                       <li><a id="export-open-stackblitz"href="#" onclick="exporter.openProjectInStackBlitz()">Open in StackBlitz</a></li>

--- a/public/index.html
+++ b/public/index.html
@@ -363,7 +363,7 @@ img {
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Export <span class="caret"></span></a>
                     <ul class="dropdown-menu">
-                      <li><a id="export-create-gh-issue" href="#">Report GitHub issue on TypeScript</a></li>
+                      <li><a id="export-create-gh-issue" href="#" onclick="exporter.reportIssue()">Report GitHub issue on TypeScript</a></li>
                       <li><a id="export-copy-markdown" href="#">Copy as Markdown</a></li>
                       <li role="separator" class="divider"></li>
                       <li><a id="export-open-code-sandbox" href="#" onclick="exporter.openProjectInCodeSandbox()">Open in CodeSandbox</a></li>

--- a/public/main-2.js
+++ b/public/main-2.js
@@ -1303,16 +1303,33 @@ console.log(message);
         }
       };
 
-      fetch("https://codesandbox.io/api/v1/sandboxes/define?json=1", {
-        method: "POST",
-        body: JSON.stringify({ files }),
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json"
-        }
-      })
-      .then(x => x.json())
-      .then(data => { window.open('https://codesandbox.io/s/'+data.sandbox_id, '_blank'); });
+      // Using the v1 get API
+      const parameters = LZString.compressToBase64(JSON.stringify({ files }))
+        .replace(/\+/g, "-") // Convert '+' to '-'
+        .replace(/\//g, "_") // Convert '/' to '_'
+        .replace(/=+$/, ""); // Remove ending '='
+
+      const url = `https://codesandbox.io/api/v1/sandboxes/define?view=editor&parameters=${parameters}`;
+      document.location = url
+
+      // Alternative using the http URL API, which uses POST. This has the trade-off where
+      // the async nature of the call means that the redirect at the end triggers
+      // popup security mechanisms in browsers because the function isn't blessed as
+      // being a direct result of a user action.
+
+      // fetch("https://codesandbox.io/api/v1/sandboxes/define?json=1", {
+      //   method: "POST",
+      //   body: JSON.stringify({ files }),
+      //   headers: {
+      //     Accept: "application/json",
+      //     "Content-Type": "application/json"
+      //   }
+      // })
+      // .then(x => x.json())
+      // .then(data => { 
+      //   window.open('https://codesandbox.io/s/' + data.sandbox_id, '_blank'); 
+      // });
+
     }
 
     function makeMarkdown() {

--- a/public/main-2.js
+++ b/public/main-2.js
@@ -1334,11 +1334,18 @@ console.log(message);
       window.open('https://github.com/Microsoft/TypeScript/issues/new?body=' + encodeURIComponent(body))
     }
 
+    function copyAsMarkdown() {
+      if ("clipboard" in navigator) {
+        navigator.clipboard.writeText(makeMarkdown());
+      }
+    }
+
 
     return {
       openProjectInStackBlitz,
       openProjectInCodeSandbox,
-      reportIssue
+      reportIssue,
+      copyAsMarkdown
     }
   }
 

--- a/public/main-2.js
+++ b/public/main-2.js
@@ -1315,7 +1315,7 @@ console.log(message);
       .then(data => { window.open('https://codesandbox.io/s/'+data.sandbox_id, '_blank'); });
     }
 
-    function makeMarkDown() {
+    function makeMarkdown() {
       return `**TypeScript ${typescriptVersion}**\n`
         + `[Playground link](${window.location})\n`
         + `\nCompiler Options:\n`
@@ -1328,10 +1328,17 @@ console.log(message);
         ;
     }
 
+    function reportIssue() {
+      const body = makeMarkdown();
+
+      window.open('https://github.com/Microsoft/TypeScript/issues/new?body=' + encodeURIComponent(body))
+    }
+
 
     return {
       openProjectInStackBlitz,
-      openProjectInCodeSandbox
+      openProjectInCodeSandbox,
+      reportIssue
     }
   }
 

--- a/public/main-2.js
+++ b/public/main-2.js
@@ -1315,6 +1315,19 @@ console.log(message);
       .then(data => { window.open('https://codesandbox.io/s/'+data.sandbox_id, '_blank'); });
     }
 
+    function makeMarkDown() {
+      return `**TypeScript ${typescriptVersion}**\n`
+        + `[Playground link](${window.location})\n`
+        + `\nCompiler Options:\n`
+        + `\`\`\`json\n${stringifiedCompilerOptions}\n\`\`\`\n`
+        + `\n**Input:**\n`
+        + `\`\`\`typescript\n${State.inputModel.getValue()}\n\`\`\`\n`
+        + `\n**Output:**\n`
+        + `\`\`\`javascript\n${State.outputModel.getValue()}\n\`\`\`\n`
+        + `\n**Expected behavior:**\n`
+        ;
+    }
+
 
     return {
       openProjectInStackBlitz,

--- a/public/main-2.js
+++ b/public/main-2.js
@@ -998,6 +998,67 @@ const message: string = 'hello world';
 console.log(message);
   `.trim();
     },
+
+    showModal(code) {
+      const existingPopover = document.getElementById("popover-modal")
+      if (existingPopover) existingPopover.parentElement.removeChild(existingPopover)
+
+      const modalBG = document.createElement("div")
+      modalBG.id = "popover-background"
+      document.body.appendChild(modalBG)
+
+      const modal = document.createElement("div")
+      modal.id = "popover-modal"
+
+      const pre = document.createElement("pre")
+      modal.appendChild(pre)
+      pre.textContent = code
+
+      const copyButton = document.createElement("button")
+      copyButton.innerText = "Copy"
+      modal.appendChild(copyButton)
+      
+      const closeButton = document.createElement("button")
+      closeButton.innerText = "Close"
+      modal.appendChild(closeButton)
+
+      document.body.appendChild(modal)
+
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(pre);
+      selection.removeAllRanges();
+      selection.addRange(range);
+
+      const close = () => {
+        modalBG.parentNode.removeChild(modalBG)
+        modal.parentNode.removeChild(modal)
+        document.onkeydown = undefined
+      }
+
+      const copy = () => {
+        navigator.clipboard.writeText(code);
+      }
+
+      modalBG.onclick = close
+      closeButton.onclick = close
+      copyButton.onclick = copy
+
+      // Support hiding the modal via escape
+      document.onkeydown = function(evt) {
+        evt = evt || window.event;
+        var isEscape = false;
+        if ("key" in evt) {
+            isEscape = (evt.key === "Escape" || evt.key === "Esc");
+        } else {
+            isEscape = (evt.keyCode === 27);
+        }
+        if (isEscape) {
+            close()
+        }
+    };
+
+    }
   };
 
   window.MonacoEnvironment = {
@@ -1265,7 +1326,7 @@ console.log(message);
         template: "typescript",
         files: {
           "index.ts": State.inputModel.getValue(),
-          "tsconfig.json":stringifiedCompilerOptions,
+          "tsconfig.json": stringifiedCompilerOptions,
         },
         dependencies: {
           "typescript": typescriptVersion
@@ -1351,18 +1412,32 @@ console.log(message);
       window.open('https://github.com/Microsoft/TypeScript/issues/new?body=' + encodeURIComponent(body))
     }
 
-    function copyAsMarkdown() {
-      if ("clipboard" in navigator) {
-        navigator.clipboard.writeText(makeMarkdown());
-      }
+    function copyAsMarkdownIssue() {
+        const markdown = makeMarkdown();
+        UI.showModal(markdown)
     }
 
+    function copyForChat() {
+      const chat = `[Playground Link](${window.location})`
+      UI.showModal(chat)
+    }
+
+    function copyForChatWithPreview() {
+      const ts = State.inputModel.getValue()
+      const preview = (ts.length > 200) ? ts.substring(0, 200) + "..." : ts.substring(0, 200)
+      
+      const code = "```\n" + preview + "\n```\n"
+      const chat = `${code}\n[Playground Link](${window.location})`
+      UI.showModal(chat)
+    }
 
     return {
       openProjectInStackBlitz,
       openProjectInCodeSandbox,
       reportIssue,
-      copyAsMarkdown
+      copyAsMarkdownIssue,
+      copyForChat,
+      copyForChatWithPreview
     }
   }
 

--- a/public/style-2.css
+++ b/public/style-2.css
@@ -407,3 +407,27 @@ label {
   height: 100%;
   flex-direction: column;
 }
+
+#popover-background {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+#popover-modal {
+  width: 80%;
+  height: 70%;
+  position: fixed;
+  padding: 20px;
+  background-color: white;
+  /* https://stackoverflow.com/questions/2005954/center-a-positionfixed-element */
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+#popover-modal pre {
+  max-height: 90%;
+  overflow: scroll;;
+}


### PR DESCRIPTION
Based on #29 , feel free to give feedback.

Current added export options:
- Report GitHub issue on TypeScript
- Copy as Markdown (currently only copy the same Github issue markdown to clipboard, like [prettier playground)](https://prettier.io/playground/)
- Open in CodeSandbox
- Open in StackBlitz (implemented in #29 )