### PR TITLE
Add selectable editor themes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -455,6 +455,16 @@ img {
         e.stopPropagation();
       });
 
+      // So that the CSS for a theme is applied before monaco is loaded
+      const theme = localStorage.getItem("editor-theme")
+      // So dark and dark-hc can share CSS
+      if (theme === "dark-hc") {
+          document.body.classList.add("dark")
+          document.body.classList.add("hc")
+        } else {
+          document.body.classList.add(theme)
+      }
+
     </script>
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -392,6 +392,15 @@ img {
               </li>
 
               <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Theme <span class="caret"></span></a>
+                <ul class="dropdown-menu">
+                  <li><a id="theme-light" href="#" onclick="setEditorTheme('light')">Light</a></li>
+                  <li><a id="theme-dark" href="#" onclick="setEditorTheme('dark')">Dark</a></li>
+                  <li><a id="theme-dark-hc" href="#" onclick="setEditorTheme('dark-hc')">Dark (High Contrast)</a></li>
+                </ul>
+              </li>
+
+              <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
                 <ul class="dropdown-menu">
                   <div class="info">

--- a/public/main-2.js
+++ b/public/main-2.js
@@ -1017,7 +1017,7 @@ console.log(message);
       const copyButton = document.createElement("button")
       copyButton.innerText = "Copy"
       modal.appendChild(copyButton)
-      
+
       const closeButton = document.createElement("button")
       closeButton.innerText = "Close"
       modal.appendChild(closeButton)
@@ -1389,8 +1389,8 @@ console.log(message);
       //   }
       // })
       // .then(x => x.json())
-      // .then(data => { 
-      //   window.open('https://codesandbox.io/s/' + data.sandbox_id, '_blank'); 
+      // .then(data => {
+      //   window.open('https://codesandbox.io/s/' + data.sandbox_id, '_blank');
       // });
 
     }
@@ -1427,7 +1427,7 @@ console.log(message);
     function copyForChatWithPreview() {
       const ts = State.inputModel.getValue()
       const preview = (ts.length > 200) ? ts.substring(0, 200) + "..." : ts.substring(0, 200)
-      
+
       const code = "```\n" + preview + "\n```\n"
       const chat = `${code}\n[Playground Link](${window.location})`
       UI.showModal(chat)
@@ -1504,6 +1504,7 @@ function setEditorTheme(theme) {
     ? localStorage.getItem("editor-theme") || "light"
     : "light";
   monaco.editor.setTheme(newTheme);
+
   document
     .querySelectorAll("a[id^=theme-]")
     .forEach(anchor =>
@@ -1511,7 +1512,18 @@ function setEditorTheme(theme) {
         ? anchor.classList.add("current-theme")
         : anchor.classList.remove("current-theme")
     );
+
   localStorage.setItem("editor-theme", newTheme);
+
+  // Sets the theme on the body so CSS can change between themes
+  document.body.classList.remove("light", "dark", "hc")
+  // So dark and dark-hc can share CSS
+  if (newTheme === "dark-hc") {
+    document.body.classList.add("dark")
+    document.body.classList.add("hc")
+  } else {
+    document.body.classList.add(newTheme)
+  }
 }
 
 const blue = "3771EF";

--- a/public/main-2.js
+++ b/public/main-2.js
@@ -1080,8 +1080,10 @@ console.log(message);
   const outputDefault = window.CONFIG.useJavaScript ? "// Using JavaScript, no compilation needed." : ""
   State.outputModel = monaco.editor.createModel(outputDefault, "javascript", monaco.Uri.file("output.js"));
 
-  monaco.editor.defineTheme("sandbox", sandboxTheme)
-  monaco.editor.setTheme("sandbox")
+  for (const [themeName, theme] of Object.entries(editorThemes)) {
+    monaco.editor.defineTheme(themeName, theme)
+  }
+  setEditorTheme()
 
   inputEditor = monaco.editor.create(
     document.getElementById("input"),
@@ -1495,6 +1497,23 @@ function objectToQueryParams(obj) {
 
 // Color theme:
 
+function setEditorTheme(theme) {
+  const newTheme = theme
+    ? theme
+    : localStorage
+    ? localStorage.getItem("editor-theme") || "light"
+    : "light";
+  monaco.editor.setTheme(newTheme);
+  document
+    .querySelectorAll("a[id^=theme-]")
+    .forEach(anchor =>
+      anchor.id === `theme-${newTheme}`
+        ? anchor.classList.add("current-theme")
+        : anchor.classList.remove("current-theme")
+    );
+  localStorage.setItem("editor-theme", newTheme);
+}
+
 const blue = "3771EF";
 const darkerBlue = "1142AF";
 const darkestBlue = "09235D";
@@ -1508,61 +1527,75 @@ const green = "12CD0E";
 const greenDark = "10990D";
 const greenLight = "54F351";
 
-const sandboxTheme = {
-  base: "vs",
-  inherit: true,
-  rules: [
-    { token: "", foreground: "000000", background: "fffffe" },
-    { token: "invalid", foreground: "cd3131" },
-    { token: "emphasis", fontStyle: "italic" },
-    { token: "strong", fontStyle: "bold" },
+const editorThemes = {
+  light: {
+    base: "vs",
+    inherit: true,
+    rules: [
+      { token: "", foreground: "000000", background: "fffffe" },
+      { token: "invalid", foreground: "cd3131" },
+      { token: "emphasis", fontStyle: "italic" },
+      { token: "strong", fontStyle: "bold" },
 
-    { token: "variable", foreground: "11bb11" },
-    { token: "variable.predefined", foreground: "4864AA" },
-    { token: "constant", foreground: "44ee11" },
-    { token: "comment", foreground: grey },
-    { token: "number", foreground: greenDark },
-    { token: "number.hex", foreground: "3030c0" },
-    { token: "regexp", foreground: greenLight },
-    { token: "annotation", foreground: "808080" },
-    { token: "type", foreground: darkerBlue },
+      { token: "variable", foreground: "11bb11" },
+      { token: "variable.predefined", foreground: "4864AA" },
+      { token: "constant", foreground: "44ee11" },
+      { token: "comment", foreground: grey },
+      { token: "number", foreground: greenDark },
+      { token: "number.hex", foreground: "3030c0" },
+      { token: "regexp", foreground: greenLight },
+      { token: "annotation", foreground: "808080" },
+      { token: "type", foreground: darkerBlue },
 
-    { token: "delimiter", foreground: "000000" },
-    { token: "delimiter.html", foreground: "383838" },
-    { token: "delimiter.xml", foreground: "0000FF" },
+      { token: "delimiter", foreground: "000000" },
+      { token: "delimiter.html", foreground: "383838" },
+      { token: "delimiter.xml", foreground: "0000FF" },
 
-    { token: "tag", foreground: "800000" },
-    { token: "tag.id.pug", foreground: "4F76AC" },
-    { token: "tag.class.pug", foreground: "4F76AC" },
-    { token: "meta.scss", foreground: "800000" },
-    { token: "metatag", foreground: "e00000" },
-    { token: "metatag.content.html", foreground: "FF0000" },
-    { token: "metatag.html", foreground: "808080" },
-    { token: "metatag.xml", foreground: "808080" },
-    { token: "metatag.php", fontStyle: "bold" },
+      { token: "tag", foreground: "800000" },
+      { token: "tag.id.pug", foreground: "4F76AC" },
+      { token: "tag.class.pug", foreground: "4F76AC" },
+      { token: "meta.scss", foreground: "800000" },
+      { token: "metatag", foreground: "e00000" },
+      { token: "metatag.content.html", foreground: "FF0000" },
+      { token: "metatag.html", foreground: "808080" },
+      { token: "metatag.xml", foreground: "808080" },
+      { token: "metatag.php", fontStyle: "bold" },
 
-    { token: "key", foreground: "863B00" },
-    { token: "string.key.json", foreground: "A31515" },
-    { token: "string.value.json", foreground: "0451A5" },
+      { token: "key", foreground: "863B00" },
+      { token: "string.key.json", foreground: "A31515" },
+      { token: "string.value.json", foreground: "0451A5" },
 
-    { token: "attribute.name", foreground: "FFFF00" },
-    { token: "attribute.value", foreground: "0451A5" },
-    { token: "attribute.value.number", foreground: "09885A" },
-    { token: "attribute.value.unit", foreground: "09885A" },
-    { token: "attribute.value.html", foreground: "0000FF" },
-    { token: "attribute.value.xml", foreground: "0000FF" },
+      { token: "attribute.name", foreground: "FFFF00" },
+      { token: "attribute.value", foreground: "0451A5" },
+      { token: "attribute.value.number", foreground: "09885A" },
+      { token: "attribute.value.unit", foreground: "09885A" },
+      { token: "attribute.value.html", foreground: "0000FF" },
+      { token: "attribute.value.xml", foreground: "0000FF" },
 
-    { token: "string", foreground: greenDark },
+      { token: "string", foreground: greenDark },
 
-    { token: "keyword", foreground: blue },
-    { token: "keyword.json", foreground: "0451A5" }
-  ],
-  colors: {
-    editorBackground: "#F6F6F6",
-    editorForeground: "#000000",
-    editorInactiveSelection: "#E5EBF1",
-    editorIndentGuides: "#D3D3D3",
-    editorActiveIndentGuides: "#939393",
-    editorSelectionHighlight: "#ADD6FF4D"
+      { token: "keyword", foreground: blue },
+      { token: "keyword.json", foreground: "0451A5" }
+    ],
+    colors: {
+      editorBackground: "#F6F6F6",
+      editorForeground: "#000000",
+      editorInactiveSelection: "#E5EBF1",
+      editorIndentGuides: "#D3D3D3",
+      editorActiveIndentGuides: "#939393",
+      editorSelectionHighlight: "#ADD6FF4D"
+    }
+  },
+  dark: {
+    base: "vs-dark",
+    inherit: true,
+    rules: [],
+    colors: {},
+  },
+  "dark-hc": {
+    base: "hc-black",
+    inherit: true,
+    rules: [],
+    colors: {},
   }
 };

--- a/public/style-2.css
+++ b/public/style-2.css
@@ -431,3 +431,8 @@ label {
   max-height: 90%;
   overflow: scroll;;
 }
+
+.current-theme:before {
+  /* prepend check mark */
+  content: "\2713  ";
+}

--- a/public/style-2.css
+++ b/public/style-2.css
@@ -432,7 +432,42 @@ label {
   overflow: scroll;;
 }
 
+/* Adds a tickbox to the selected theme */
+
 .current-theme:before {
   /* prepend check mark */
   content: "\2713  ";
+}
+
+.current-theme {
+  margin-left: -1em;
+}
+
+body.dark {
+  background-color: #1e1e1e;
+}
+
+body.dark .nav a {
+  color: white;
+}
+
+body.dark .dropdown-menu {
+  background-color: black;
+  color: white;
+}
+
+body.dark .navbar-sub div.info {
+  color: white;
+}
+
+body.dark .nav>li>a:focus, body.dark .nav>li>a:hover {
+  background-color: #4e4e4e;
+}
+
+body.dark .dropdown-menu>li>a:focus, body.dark  .dropdown-menu>li>a:hover {
+  background-color: #4e4e4e;
+}
+
+body.dark.hc {
+  background-color: black;
 }


### PR DESCRIPTION
This adds a new 'Theme' dropdown menu to the playground. Themes include:

- light (current playground theme)
- dark
- dark with high contrast

On load all themes are registered, and them localStorage is checked for
any saved theme, defaulting to 'light'.  Updates store the last selected
theme in localStorage.

Related: microsoft/TypeScript-Website#90