### PR TITLE
When in JS mode and on 3.7+, the other half of the window is set to be the d.ts of the JS

### DIFF
--- a/public/main-3.js
+++ b/public/main-3.js
@@ -1152,7 +1152,7 @@ console.log(message);
     document.getElementById("output"),
     Object.assign({
       model: State.outputModel,
-      readOnly: window.CONFIG.useJavaScript
+      readOnly: true
     }, sharedEditorOptions),
   );
 

--- a/public/main-3.js
+++ b/public/main-3.js
@@ -392,6 +392,7 @@ async function main() {
 
     checkJs: trueInJS,
     allowJs: trueInJS,
+    declaration: true,
 
     experimentalDecorators: false,
     emitDecoratorMetadata: false,
@@ -1174,9 +1175,16 @@ console.log(message);
         const sourceCode =  userInput.getValue()
         LibManager.detectNewImportsToAcquireTypeFor(sourceCode)
 
-        if(!isJS) {
+        if(!isJS || UI.allowJSDeclarations) {
           client.getEmitOutput(userInput.uri.toString()).then(result => {
-            State.outputModel.setValue(result.outputFiles[0].text);
+            const filename = isJS ? "input.d.ts": "input.js"
+            const emitFile = result.outputFiles.find(f => f.name.includes(filename)) || result.outputFiles[0]
+
+            let outputText = emitFile.text
+            const isDefaultInJS = isJS && sourceCode.trim().length === 0
+
+            if (isDefaultInJS) outputText = "// In JS Mode for 3.7 and above, the playground will\n// show the d.ts for your JavaScript code"
+            State.outputModel.setValue(outputText);
           });
         }
       });
@@ -1212,6 +1220,11 @@ console.log(message);
   require(["vs/language/typescript/tsWorker"], () => {
     require(["vs/language/typescript/lib/typescriptServices"], () => {
       window.ts = ts
+
+      if (window.ts) {
+        const version = window.ts.versionMajorMinor.split(".")
+        UI.allowJSDeclarations = Number(version[0]) >= 3 && Number(version[1]) >= 7
+      }
     })
   })
 


### PR DESCRIPTION
Now that a JS file can safely emit d.ts in TypeScript 3.7 - we should use that

When we know the compiler is 3.7 and above, and in JS, then the default message changes

![Screen Shot 2019-11-27 at 6 28 28 PM](https://user-images.githubusercontent.com/49038/69766059-677e4c00-1144-11ea-8ffa-55a446400092.png)

Then adding a JS file will show the d.ts emit

![Screen Shot 2019-11-27 at 6 31 07 PM](https://user-images.githubusercontent.com/49038/69766084-79f88580-1144-11ea-95e6-b993b7749fa1.png)
