### PR TITLE
Fix closing tags for <b> in exported github issue

### DIFF
--- a/public/main-3.js
+++ b/public/main-3.js
@@ -1469,14 +1469,14 @@ Please fill in the *entire* template below.
 ${codify(State.inputModel.getValue(), "ts")}
 
 
-<details><summary><b>Output<b></summary>
+<details><summary><b>Output</b></summary>
 
 ${codify(State.outputModel.getValue(), "ts")}
 
 </details>
 
 
-<details><summary><b>Compiler Options<b></summary>
+<details><summary><b>Compiler Options</b></summary>
 
 ${codify(stringifiedCompilerOptions, "json")}
 


### PR DESCRIPTION
When exporting as a new github issue, the `<b>` tags were unmatched, causing any text added after the template to be bold.