### PR TITLE
Fix Playground v3 link and cursor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -195,6 +195,9 @@ img {
 
 .navbar-default .navbar-toggle {
   border: none; }
+
+#playground-v3-link {
+  cursor: pointer; }
     </style>
   </head>
 
@@ -476,7 +479,7 @@ img {
 
       $('#playground-v3-link').on('click', function(e) {
         e.stopPropagation();
-        document.location = "http://www.staging-typescript.org/play" + document.location.search + document.location.hash || ""
+        document.location = "https://www.staging-typescript.org/play" + document.location.search + document.location.hash || ""
       });
 
       // So that the CSS for a theme is applied before monaco is loaded


### PR DESCRIPTION
Noticed that Try Playground v3 beta link has two problems:
1. Cursor over the link displayed as `cursor: text` because link doesn't have `href`
1. Click on link results in error page

![image](https://user-images.githubusercontent.com/1312662/84438934-003b6b80-ac40-11ea-9f81-1424cce258f5.png)


This PR forces proper cursor on link and makes sure that redirect is to `https` which will work as expected

P.S. Maybe it worth to mention that any changes to `/play` page should be made in this repo. Somehow I thought that header is rendered in https://github.com/microsoft/TypeScript-Website/ repo and had hard time finding Try Playground v3 beta link there. 😆 